### PR TITLE
fwatcher 2.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 
 [![fwatcher](http://i.imgur.com/vy4T9a6.png)](#)
 
-# fwatcher [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/fwatcher.svg)](https://www.npmjs.com/package/fwatcher) [![Downloads](https://img.shields.io/npm/dt/fwatcher.svg)](https://www.npmjs.com/package/fwatcher) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# fwatcher
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/fwatcher.svg)](https://www.npmjs.com/package/fwatcher) [![Downloads](https://img.shields.io/npm/dt/fwatcher.svg)](https://www.npmjs.com/package/fwatcher) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Watch files for changes.
 
@@ -69,13 +71,6 @@ the evenit name and the third one is the file path.
 ## :yum: How to contribute
 Have an idea? Found a bug? See [how to contribute][contributing].
 
-## :dizzy: Where is this library used?
-If you are using this library in one of your projects, add it in this list. :sparkles:
-
-
- - [`ape-watching`](https://github.com/ape-repo/ape-watching#readme) (by Taka Okunishi)—ape framework module for watching files.
- - [`element-status`](https://github.com/callahanrts/element#readme) (by CallahanRTS)—An electron based status bar
- - [`web-term`](https://github.com/IonicaBizau/web-term)—A full screen terminal in your browser.
 
 ## :scroll: License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fwatcher",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Watch files for changes.",
   "main": "lib/index.js",
   "directories": {
@@ -43,6 +43,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
